### PR TITLE
fix: security hardening — WIQL injection, PAT exposure, error handling

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -16,9 +16,14 @@ const defaultAPIVersion = "7.1"
 // Client is an Azure DevOps REST API client.
 type Client struct {
 	BaseURL    string
-	PAT        string
+	pat        string
 	APIVersion string
 	HTTP       *http.Client
+}
+
+// String returns a safe representation of the client that redacts the PAT.
+func (c *Client) String() string {
+	return fmt.Sprintf("Client{BaseURL: %s, APIVersion: %s}", c.BaseURL, c.APIVersion)
 }
 
 // NewClient creates a Client for the given Azure DevOps organization.
@@ -26,7 +31,7 @@ type Client struct {
 func NewClient(org, pat string) *Client {
 	return &Client{
 		BaseURL:    fmt.Sprintf("https://dev.azure.com/%s/_apis", org),
-		PAT:        pat,
+		pat:        pat,
 		APIVersion: defaultAPIVersion,
 		HTTP:       &http.Client{},
 	}
@@ -34,7 +39,7 @@ func NewClient(org, pat string) *Client {
 
 // authHeader returns the Basic auth header value for PAT authentication.
 func (c *Client) authHeader() string {
-	token := base64.StdEncoding.EncodeToString([]byte(":" + c.PAT))
+	token := base64.StdEncoding.EncodeToString([]byte(":" + c.pat))
 	return "Basic " + token
 }
 


### PR DESCRIPTION
## Summary

- **Prevent WIQL injection**: Escape single quotes in user-supplied `--type`, `--state`, and `--assigned-to` flag values before interpolating into WIQL queries. Without this, crafted input like `Bug' OR 1=1 OR [System.State]='` could bypass query filters and expose unintended work items.
- **Unexport `Client.PAT` field**: Renamed `Client.PAT` to `Client.pat` (unexported) so the token cannot leak through `fmt.Sprintf("%+v", client)`, debug logging, or reflection-based serialization. Added a `String()` method that redacts the PAT.
- **Handle `resolveProject` errors in `show`/`update`**: `workitem show` and `workitem update` were silently discarding the error from `resolveProject`, causing confusing HTTP 404s when no project was configured. Now returns the helpful error message like `list` and `create` already do.

## Test plan

- [ ] `ado workitem list --type "Bug' OR 1=1 OR [System.State]='" --project myproject` should not bypass filters
- [ ] `ado workitem show 123` without a configured project should return a clear error, not a 404
- [ ] `ado workitem update 123 --title "test"` without a configured project should return a clear error
- [ ] `go build ./...` and `go vet ./...` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)